### PR TITLE
Refactor collecte instructions to use per-question guidance

### DIFF
--- a/src/Support/CollecteFlow.php
+++ b/src/Support/CollecteFlow.php
@@ -5,7 +5,13 @@ namespace Questionnaire\Support;
 final class CollecteFlow
 {
     /**
-     * @var array<int, array{id: string, order: int, label: string, prompt: string}>
+     * @var array<int, array{
+     *     id: string,
+     *     order: int,
+     *     label: string,
+     *     prompt: string,
+     *     instructions: list<string>
+     * }>
      */
     private const QUESTIONS = [
         [
@@ -17,59 +23,96 @@ final class CollecteFlow
             // plus imposée par le système, mais ce texte sert de base pour relancer
             // l'utilisateur si nécessaire.
             'prompt' => "Quel est le nom de l'entreprise, son secteur d'activité, son positionnement et ses principaux concurrents ?",
+            'instructions' => [
+                "Utilise l’Outil Recherche Auto pour analyser le dernier message utilisateur et détecter une entreprise ou une enseigne.",
+                "Si tu en identifies une, réponds au format : «J’ai détecté [Nom] dans votre demande. Recherche auto : Secteur [secteur], Positionnement [positionnement], Concurrents [concurrents]. Correct ? Sinon, précisez.»",
+                "Si aucune enseigne n'est détectée, pose la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'cible',
             'order' => 2,
             'label' => 'Cible',
             'prompt' => "Qui est votre public cible ? Décrivez les caractéristiques démographiques et psychographiques (âge, sexe, localisation, CSP, clients vs prospects) et précisez les quotas ou segments d'analyse souhaités.",
+            'instructions' => [
+                "Analyse la réponse précédente pour suggérer des quotas types (âge, genre, localisation) si cela peut aider la réflexion.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'echantillon',
             'order' => 3,
             'label' => 'Échantillon',
             'prompt' => "Quelle est la taille de l'échantillon prévue et la durée cible du questionnaire (<10 min, 10-20 questions) ?",
+            'instructions' => [
+                "Rappelle les durées usuelles (moins de 10 min, 10-20 questions) si l'utilisateur n'a pas encore précisé ce point.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'nombre_questions',
             'order' => 4,
             'label' => 'Nombre de questions souhaitées',
             'prompt' => "Combien de questions voulez-vous exactement dans le questionnaire ?",
+            'instructions' => [
+                "Reformule la demande pour confirmer le volume de questions attendu.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'mode',
             'order' => 5,
             'label' => 'Mode',
             'prompt' => 'Quel est le mode de collecte prévu (téléphone, online/email, face-à-face, papier, panel, observation) ?',
+            'instructions' => [
+                "Présente les principaux modes de collecte possibles et invite l'utilisateur à confirmer ou compléter son choix.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'contexte',
             'order' => 6,
             'label' => 'Contexte',
             'prompt' => "Quel est le contexte stratégique de cette étude (suivi annuel, définition de segments, choix d'offre, analyse de prix, test d'offre, etc.) ?",
+            'instructions' => [
+                "Reformule brièvement le contexte stratégique déjà partagé pour montrer que tu l'as bien compris.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'thematiques',
             'order' => 7,
             'label' => 'Thématiques',
             'prompt' => 'Quelles sont les thématiques prioritaires à couvrir (satisfaction, notoriété, intention d\'achat, prix, etc.) ? Listez-les par ordre de priorité.',
+            'instructions' => [
+                "Suggère quelques thématiques classiques si l'utilisateur ne sait pas par où commencer.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'sensibilites',
             'order' => 8,
             'label' => 'Sensibilités',
             'prompt' => "Y a-t-il des thèmes sensibles (santé, argent, religion, etc.) ou des contraintes culturelles/linguistiques à prendre en compte ?",
+            'instructions' => [
+                "Précise l'importance de respecter les contraintes légales et culturelles associées aux thèmes sensibles.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
         [
             'id' => 'introduction',
             'order' => 9,
             'label' => 'Introduction',
             'prompt' => "Dois-je écrire un mail d'invitation ou une introduction pour l'enquêteur (ou les deux) ?",
+            'instructions' => [
+                "Invite l'utilisateur à préciser s'il souhaite un mail d'invitation, une introduction enquêteur ou les deux.",
+                "Pose ensuite la question suivante : «{{prompt}}».",
+            ],
         ],
     ];
 
     /**
-     * @return array<int, array{id: string, order: int, label: string, prompt: string, index: int}>
+     * @return array<int, array{id: string, order: int, label: string, prompt: string, instructions: list<string>, index: int}>
      */
     public static function questions(): array
     {
@@ -87,7 +130,7 @@ final class CollecteFlow
     }
 
     /**
-     * @return array{id: string, order: int, label: string, prompt: string, index: int}|null
+     * @return array{id: string, order: int, label: string, prompt: string, instructions: list<string>, index: int}|null
      */
     public static function getQuestion(int $index): ?array
     {
@@ -99,7 +142,7 @@ final class CollecteFlow
     }
 
     /**
-     * @return array{id: string, order: int, label: string, prompt: string, index: int}|null
+     * @return array{id: string, order: int, label: string, prompt: string, instructions: list<string>, index: int}|null
      */
     public static function getById(string $id): ?array
     {
@@ -113,8 +156,28 @@ final class CollecteFlow
     }
 
     /**
-     * @param array{id: string, order: int, label: string, prompt: string} $question
-     * @return array{id: string, order: int, label: string, prompt: string, index: int}
+     * @return list<string>
+     */
+    public static function instructions(string $id): array
+    {
+        $question = self::getById($id);
+        if ($question === null || !isset($question['instructions']) || !is_array($question['instructions'])) {
+            return [];
+        }
+
+        $instructions = [];
+        foreach ($question['instructions'] as $line) {
+            if (is_string($line) && $line !== '') {
+                $instructions[] = $line;
+            }
+        }
+
+        return $instructions;
+    }
+
+    /**
+     * @param array{id: string, order: int, label: string, prompt: string, instructions: list<string>} $question
+     * @return array{id: string, order: int, label: string, prompt: string, instructions: list<string>, index: int}
      */
     private static function withIndex(array $question, int $index): array
     {

--- a/tests/Support/OpenAIClientTest.php
+++ b/tests/Support/OpenAIClientTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Questionnaire\Support\CollecteFlow;
+use Questionnaire\Support\OpenAIClient;
+
+$autoload = __DIR__ . '/../../vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
+
+spl_autoload_register(static function (string $class): void {
+    if (!str_starts_with($class, 'Questionnaire\\')) {
+        return;
+    }
+
+    $relative = substr($class, strlen('Questionnaire\\'));
+    $path = __DIR__ . '/../../src/' . str_replace('\\', '/', $relative) . '.php';
+    if (file_exists($path)) {
+        require_once $path;
+    }
+});
+
+if (!class_exists('GuzzleHttp\\Client')) {
+    class OpenAIClientTestGuzzleStub
+    {
+        public function __construct(array $config = [])
+        {
+        }
+    }
+
+    class_alias(OpenAIClientTestGuzzleStub::class, 'GuzzleHttp\\Client');
+}
+
+$client = new OpenAIClient();
+
+$questions = CollecteFlow::questions();
+
+foreach ($questions as $question) {
+    $session = [
+        'id' => 'test-session',
+        'promptVersion' => 'test',
+        'phase' => 'collecte',
+        'summary' => '',
+        'recentTurns' => [],
+        'collecte' => [
+            'nextIndex' => $question['index'],
+            'answers' => [],
+        ],
+    ];
+
+    foreach ($questions as $previous) {
+        if ($previous['index'] < $question['index']) {
+            $session['collecte']['answers'][$previous['id']] = 'filled';
+        }
+    }
+
+    $payload = $client->buildPayload($session, 'Bonjour');
+
+    if (!isset($payload['input'][0]['content'][0]['text'])) {
+        throw new RuntimeException('Le message système de collecte est introuvable.');
+    }
+
+    $systemMessage = $payload['input'][0]['content'][0]['text'];
+
+    $expectedInstructions = CollecteFlow::instructions($question['id']);
+    if ($expectedInstructions === []) {
+        $expectedInstructions = [sprintf('Pose la question suivante : «%s».', $question['prompt'])];
+    }
+
+    foreach ($expectedInstructions as $instruction) {
+        $resolvedInstruction = str_replace('{{prompt}}', $question['prompt'], $instruction);
+        if (!str_contains($systemMessage, $resolvedInstruction)) {
+            throw new RuntimeException(sprintf(
+                "L'instruction attendue est absente pour la question %s : %s",
+                $question['id'],
+                $resolvedInstruction
+            ));
+        }
+    }
+
+    if (!str_contains($systemMessage, '⚠️ Attente réponse utilisateur')) {
+        throw new RuntimeException(sprintf(
+            "Le message de terminaison est absent pour la question %s.",
+            $question['id']
+        ));
+    }
+}
+
+echo "OpenAIClient instructions test passed.\n";


### PR DESCRIPTION
## Summary
- enrich CollecteFlow questions with per-question guidance lines
- refactor OpenAIClient to build system instructions from the mapped guidance
- add a test covering that each collecte question injects the expected system instructions and wait notice

## Testing
- php tests/Support/OpenAIClientTest.php

------
https://chatgpt.com/codex/tasks/task_e_68de3620c2c08330919910db815b8788