### PR TITLE
Add source traceability reminder to collecte instructions

### DIFF
--- a/src/Support/CollecteFlow.php
+++ b/src/Support/CollecteFlow.php
@@ -4,6 +4,8 @@ namespace Questionnaire\Support;
 
 final class CollecteFlow
 {
+    private const SOURCE_TRACEABILITY_INSTRUCTION = "Indique avant de poser la question quelles sources tu viens de consulter (vector store prioritaire, web search uniquement en secours si l'information manque) et justifie ce choix en rappelant la hiérarchie de la section «Gestion des sources».";
+
     /**
      * @var array<int, array{
      *     id: string,
@@ -173,6 +175,24 @@ final class CollecteFlow
         }
 
         return $instructions;
+    }
+
+    /**
+     * @param list<string> $instructions
+     * @return list<string>
+     */
+    public static function withSourceTraceability(array $instructions): array
+    {
+        if (!in_array(self::SOURCE_TRACEABILITY_INSTRUCTION, $instructions, true)) {
+            array_unshift($instructions, self::SOURCE_TRACEABILITY_INSTRUCTION);
+        }
+
+        return $instructions;
+    }
+
+    public static function sourceTraceabilityInstruction(): string
+    {
+        return self::SOURCE_TRACEABILITY_INSTRUCTION;
     }
 
     /**

--- a/src/Support/OpenAIClient.php
+++ b/src/Support/OpenAIClient.php
@@ -329,9 +329,11 @@ final class OpenAIClient
      */
     private function buildQuestionInstructions(array $pendingQuestion): array
     {
-        $instructions = CollecteFlow::instructions($pendingQuestion['id']);
-        if ($instructions === []) {
-            return [sprintf('Pose la question suivante : «%s».', $pendingQuestion['prompt'])];
+        $baseInstructions = CollecteFlow::instructions($pendingQuestion['id']);
+        $instructions = CollecteFlow::withSourceTraceability($baseInstructions);
+
+        if ($baseInstructions === []) {
+            $instructions[] = sprintf('Pose la question suivante : «%s».', $pendingQuestion['prompt']);
         }
 
         $resolved = [];

--- a/tests/Support/OpenAIClientTest.php
+++ b/tests/Support/OpenAIClientTest.php
@@ -62,9 +62,18 @@ foreach ($questions as $question) {
 
     $systemMessage = $payload['input'][0]['content'][0]['text'];
 
-    $expectedInstructions = CollecteFlow::instructions($question['id']);
-    if ($expectedInstructions === []) {
-        $expectedInstructions = [sprintf('Pose la question suivante : «%s».', $question['prompt'])];
+    $baseInstructions = CollecteFlow::instructions($question['id']);
+    $expectedInstructions = CollecteFlow::withSourceTraceability($baseInstructions);
+    if ($baseInstructions === []) {
+        $expectedInstructions[] = sprintf('Pose la question suivante : «%s».', $question['prompt']);
+    }
+
+    $traceabilityInstruction = CollecteFlow::sourceTraceabilityInstruction();
+    if (!str_contains($systemMessage, $traceabilityInstruction)) {
+        throw new RuntimeException(sprintf(
+            "L'instruction de traçabilité des sources est absente pour la question %s.",
+            $question['id']
+        ));
     }
 
     foreach ($expectedInstructions as $instruction) {


### PR DESCRIPTION
## Summary
- add a shared reminder about source traceability in the collecte flow
- ensure OpenAI question instructions always include the reminder and default prompt fallback
- extend the OpenAI client test to cover the new instruction

## Testing
- php tests/Support/OpenAIClientTest.php

------
https://chatgpt.com/codex/tasks/task_e_68de3ae910a88330ae0ac77af0bd5b00