### PR TITLE
Update collecte flow source traceability guidance

### DIFF
--- a/src/Support/CollecteFlow.php
+++ b/src/Support/CollecteFlow.php
@@ -4,7 +4,7 @@ namespace Questionnaire\Support;
 
 final class CollecteFlow
 {
-    private const SOURCE_TRACEABILITY_INSTRUCTION = "Indique avant de poser la question quelles sources tu viens de consulter (vector store prioritaire, web search uniquement en secours si l'information manque) et justifie ce choix en rappelant la hiérarchie de la section «Gestion des sources».";
+    private const SOURCE_TRACEABILITY_INSTRUCTION = "Ajoute uniquement en fin de réponse les lignes «Sources internes utilisées : …» et «Sources web utilisées : …». Priorise toujours le vector store ; n'utilise la recherche web qu'en secours si l'information manque. N'ajoute aucun autre paragraphe.";
 
     /**
      * @var array<int, array{

--- a/tests/Support/OpenAIClientTest.php
+++ b/tests/Support/OpenAIClientTest.php
@@ -76,6 +76,20 @@ foreach ($questions as $question) {
         ));
     }
 
+    if (!str_contains($systemMessage, 'Sources internes utilisées')) {
+        throw new RuntimeException(sprintf(
+            "La mention 'Sources internes utilisées' est absente pour la question %s.",
+            $question['id']
+        ));
+    }
+
+    if (!str_contains($systemMessage, 'Sources web utilisées')) {
+        throw new RuntimeException(sprintf(
+            "La mention 'Sources web utilisées' est absente pour la question %s.",
+            $question['id']
+        ));
+    }
+
     foreach ($expectedInstructions as $instruction) {
         $resolvedInstruction = str_replace('{{prompt}}', $question['prompt'], $instruction);
         if (!str_contains($systemMessage, $resolvedInstruction)) {


### PR DESCRIPTION
## Summary
- update the collecte flow traceability instruction to require the final source lines and emphasise vector-store priority
- extend the OpenAI client test to assert the updated instruction text and required source mentions

## Testing
- php tests/Support/OpenAIClientTest.php

------
https://chatgpt.com/codex/tasks/task_e_68de3f6ca46c833094db7f7f1855bc9f