### PR TITLE
Add thematic validation helper flow

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -95,6 +95,13 @@ body {
     font-size: 1.1rem;
 }
 
+.checkbox-panel .thematic-hint {
+    margin: 0 0 0.75rem;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    line-height: 1.4;
+}
+
 .thematic {
     background: rgba(17, 24, 39, 0.7);
     border: 1px solid var(--border);
@@ -164,6 +171,31 @@ body {
 .add-sub button:hover,
 .add-thematic button:hover {
     background: rgba(56, 189, 248, 0.25);
+}
+
+.validate-thematics {
+    margin-top: 1rem;
+    width: 100%;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.85) 0%, rgba(14, 165, 233, 0.95) 100%);
+    border: 1px solid rgba(56, 189, 248, 0.5);
+    color: white;
+    font-weight: 600;
+    padding: 0.65rem 1rem;
+    border-radius: 0.75rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.validate-thematics:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+.validate-thematics:not(:disabled):hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 24px rgba(56, 189, 248, 0.35);
 }
 
 .main-panel {

--- a/public/index.php
+++ b/public/index.php
@@ -28,11 +28,13 @@ require __DIR__ . '/../src/bootstrap.php';
             </section>
             <section class="checkbox-panel is-hidden">
                 <h2>Thématiques</h2>
+                <p class="thematic-hint">Sélectionnez les thématiques et sous-thématiques pertinentes avant de valider votre choix.</p>
                 <div id="thematicContainer"></div>
                 <div class="add-thematic">
                     <input type="text" id="newThematicInput" placeholder="Ajouter une thématique" />
                     <button id="addThematicButton" type="button">Ajouter</button>
                 </div>
+                <button id="validateThematicsButton" type="button" class="validate-thematics">Valider les thématiques</button>
             </section>
         </aside>
         <main class="main-panel">


### PR DESCRIPTION
## Summary
- add an explanatory hint and validation button to the thematics panel
- style the new hint and button to match the sidebar controls
- extend the client logic to gather checked thematics, reuse the submission flow, and toggle the validation button state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de497811248330ae808d8812b0d9ea