### PR TITLE
Handle source label prefixes in markdown rendering

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -151,7 +151,16 @@ function renderMarkdown(markdown) {
       return;
     }
     const normalizedText = normalize(node.textContent);
-    if (sourceLabels.includes(normalizedText)) {
+    const matchesSourceLabel = sourceLabels.some((label) => {
+      const normalizedLabel = normalize(label);
+      return (
+        normalizedText === normalizedLabel ||
+        normalizedText.startsWith(`${normalizedLabel} `) ||
+        normalizedText.startsWith(`${normalizedLabel}:`) ||
+        normalizedText.startsWith(`${normalizedLabel} :`)
+      );
+    });
+    if (matchesSourceLabel) {
       markClosestBlock(node, 'source-section');
     }
     if (normalizedText === '⚠️ Attente réponse utilisateur') {


### PR DESCRIPTION
## Summary
- extend the source-section detection logic to catch lines that start with a known source label before additional citation text
- keep highlighting applied to the entire block when the label is followed by punctuation or copy

## Testing
- node <<'NODE'
const sourceLabels = ['Sources internes utilisées', 'Sources web utilisées'];
const normalize = (value) => value.replace(/\s+/g, ' ').trim().replace(/[:\s]+$/, '');
const text = 'Sources web utilisées : Datareportal 2024';
const normalizedText = normalize(text);
const matchesSourceLabel = sourceLabels.some((label) => {
  const normalizedLabel = normalize(label);
  return (
    normalizedText === normalizedLabel ||
    normalizedText.startsWith(`${normalizedLabel} `) ||
    normalizedText.startsWith(`${normalizedLabel}:`) ||
    normalizedText.startsWith(`${normalizedLabel} :`)
  );
});
console.log({ normalizedText, matchesSourceLabel });
NODE

------
https://chatgpt.com/codex/tasks/task_e_68de66b6e5548330b7c953cdbf45bf05