### PR TITLE
Improve question heading detection

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -198,6 +198,30 @@ function renderMarkdown(markdown) {
     'Introduction',
     'Sous-thématiques'
   ].map((label) => normalizeText(label));
+  const questionHeadingDeterminerPatterns = [
+    /^l['’]\s*/,
+    /^les\s+/, 
+    /^la\s+/, 
+    /^le\s+/, 
+    /^une\s+/, 
+    /^un\s+/, 
+    /^des\s+/, 
+    /^du\s+/, 
+    /^de\s+la\s+/, 
+    /^de\s+l['’]\s*/, 
+    /^d['’]\s*/
+  ];
+  const stripQuestionHeadingDeterminer = (value) => {
+    let result = value;
+    for (const pattern of questionHeadingDeterminerPatterns) {
+      if (pattern.test(result)) {
+        result = result.replace(pattern, '');
+        break;
+      }
+    }
+    return result.trimStart();
+  };
+  const looksLikeQuestionText = (value) => /(?:\?|…|\.\.\.)\s*$/.test(value.trim());
   const questionHeadingPattern = /^(?:(?:Q\.?|Question)\s*)?(\d+)\s*[-–—]\s*(.+)$/i;
   wrapper.querySelectorAll('*').forEach((node) => {
     if (!node.textContent) {
@@ -227,7 +251,11 @@ function renderMarkdown(markdown) {
     if (headingMatch) {
       const [, , headingLabel] = headingMatch;
       const normalizedHeadingLabel = normalizeText(headingLabel.replace(/[:\s]+$/, ''));
-      if (questionHeadingLabels.some((label) => normalizedHeadingLabel.startsWith(label))) {
+      const normalizedHeadingWithoutDeterminer = stripQuestionHeadingDeterminer(normalizedHeadingLabel);
+      const matchesKnownLabel = questionHeadingLabels.some((label) =>
+        normalizedHeadingWithoutDeterminer.startsWith(label)
+      );
+      if (matchesKnownLabel || looksLikeQuestionText(headingLabel)) {
         markClosestBlock(node, 'question-heading');
       }
     }

--- a/tests/frontend/renderMarkdown.test.js
+++ b/tests/frontend/renderMarkdown.test.js
@@ -273,4 +273,10 @@ assert.equal(typeof renderMarkdown, 'function', 'renderMarkdown should be a func
 const html = renderMarkdown('Q5 — Mode');
 assert.ok(/<p[^>]*class=\"[^\"]*question-heading[^\"]*\">Q5 — Mode<\/p>/.test(html), 'Expected question-heading class on paragraph');
 
-console.log('renderMarkdown applies question-heading class when prefixing numbers with Q.');
+const determinerHtml = renderMarkdown("1 — L'entreprise");
+assert.ok(/<p[^>]*class=\"[^\"]*question-heading[^\"]*\">1 — L'entreprise<\/p>/.test(determinerHtml), 'Expected question-heading class with determiner');
+
+const questionLabelHtml = renderMarkdown('Q1 — Confirmez-vous la réception…');
+assert.ok(/<p[^>]*class=\"[^\"]*question-heading[^\"]*\">Q1 — Confirmez-vous la réception…<\/p>/.test(questionLabelHtml), 'Expected question-heading class with full question text');
+
+console.log('renderMarkdown applies question-heading class for numbered headings, determiners, and full question labels.');


### PR DESCRIPTION
## Summary
- expand question heading detection to handle labels prefixed with determiners and full question texts
- add heuristics to avoid misclassifying generic numbered lists
- cover determiner and full question scenarios in renderMarkdown tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de856128788330813427d5601c9ecf