### PR TITLE
Preserve user-entered line breaks in chat UI

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -665,8 +665,8 @@ function pushMessage(role, content, options = {}) {
     }
   } else {
     const escaped = escapeHtml(content);
-    const withLineBreaks = escaped.replace(/\r?\n/g, '<br>');
-    html = `<p>${withLineBreaks}</p>`;
+    const normalizedNewlines = escaped.replace(/\r\n?/g, '\n');
+    html = `<p class="chat-text">${normalizedNewlines}</p>`;
   }
   const message = {
     role,

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -222,13 +222,19 @@ body {
     gap: 1rem;
 }
 
-.chat-message { 
+.chat-message {
     max-width: 760px;
     border-radius: 1rem;
     padding: 1rem 1.25rem;
     line-height: 1.55;
     border: 1px solid rgba(56, 189, 248, 0.15);
     box-shadow: 0 14px 30px rgba(15, 23, 42, 0.2);
+}
+
+.chat-message .chat-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
 }
 
 .chat-message .question-heading {


### PR DESCRIPTION
## Summary
- render user messages with preserved newline characters instead of converting them to `<br>` tags
- add chat bubble text styling that keeps whitespace and line breaks while preventing layout issues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de9f9c42588330ae9362e03758ff23