### PR TITLE
Handle prefixed source headings

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -273,7 +273,11 @@ function renderMarkdown(markdown) {
 
   const normalizeWhitespace = (value) => value.replace(/\s+/g, ' ').trim();
   const normalizeForSource = (value) => {
-    const trimmed = normalizeWhitespace(value).replace(/[:\s]+$/, '');
+    const leadingTrimmed = normalizeWhitespace(value).replace(
+      /^(?:[|∣•·▪◦●○‣⁃*\-–—]+\s*)+/u,
+      ''
+    );
+    const trimmed = leadingTrimmed.replace(/[:\s]+$/u, '');
     return normalizeText(trimmed);
   };
   const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/tests/frontend/renderMarkdown.test.js
+++ b/tests/frontend/renderMarkdown.test.js
@@ -359,6 +359,21 @@ assert.ok(!/assistant-sources/.test(renderedSources.html), 'Should not append as
 const occurrences = (renderedSources.html.match(/Sources internes utilisées/g) || []).length;
 assert.equal(occurrences, 1, 'Should render only one internal sources heading');
 
+const prefixedSourcesContent = [
+  '| Sources internes utilisées : Document interne',
+  '',
+  '- Note de cadrage'
+].join('\n');
+const prefixedRendered = renderAssistantHtml(prefixedSourcesContent, { internal: [], web: [] });
+assert.equal(prefixedRendered.hasSourceSection, true, 'Expected detection with prefixed separator');
+assert.ok(
+  /<p[^>]*class=\"[^\"]*source-section[^\"]*\">\| Sources internes utilisées : Document interne[\s\S]*?<\/p>/.test(
+    prefixedRendered.html
+  ),
+  'Should mark prefixed sources heading as source-section'
+);
+assert.ok(!/assistant-sources/.test(prefixedRendered.html), 'Should not append assistant sources when prefixed heading present');
+
 const normalizedSources = normalizeSources({
   internal: ['Guide interne.md — Section 2 – Aperçu'],
   web: ['Article externe — Résumé — https://example.net/resource']


### PR DESCRIPTION
## Summary
- normalize source headings by stripping leading separators so variants like `| Sources internes...` are detected
- add a regression test to ensure prefixed headings receive the `source-section` class and skip redundant source blocks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df80f32b148330a74282a61f76a0b5