### PR TITLE
Clean response output from internal filecite markers

### DIFF
--- a/tests/Support/ResponseFormatterTest.php
+++ b/tests/Support/ResponseFormatterTest.php
@@ -312,6 +312,20 @@ namespace {
         throw new RuntimeException('Les sources web formatées sont incorrectes.');
     }
 
+    $markerPayload = [
+        'output_text' => [
+            "Introduction ∎filecite_internal_001∎\n",
+            'Suite ∎filecite-foo∎fin',
+        ],
+    ];
+
+    $formattedWithMarkers = ResponseFormatter::formatAssistantResponse($markerPayload);
+    $expectedMarkdownWithMarkers = "Introduction\nSuite fin";
+
+    if ($formattedWithMarkers['markdown'] !== $expectedMarkdownWithMarkers) {
+        throw new RuntimeException('Le nettoyage des marqueurs filecite est incorrect.');
+    }
+
     $regressionPayload = [
         'response' => [
             'output' => [


### PR DESCRIPTION
## Summary
- strip internal ∎filecite markers from assistant output before returning streaming deltas or final markdown
- ensure all text serialization paths apply the cleanup helper
- add regression coverage confirming filecite markers are removed from formatted responses

## Testing
- php tests/Support/ResponseFormatterTest.php

------
https://chatgpt.com/codex/tasks/task_e_68df8cd87274833087eeecdf7481b1ed