### PR TITLE
Ensure thematics JSON block is detected by id

### DIFF
--- a/public/assets/app.js
+++ b/public/assets/app.js
@@ -488,9 +488,26 @@ function extractThematicSuggestionsFromJson(content) {
 
     let candidates = [];
     try {
-      candidates = Array.from(
+      const dataAttributeMatches = Array.from(
         document.querySelectorAll('code[data-json-marker="thematique_suggestions"]')
       );
+      const idMatches = Array.from(
+        document.querySelectorAll('code[id^="assistant-thematique-suggestions-"]')
+      );
+      const seenNodes = new Set();
+      candidates = [];
+      dataAttributeMatches.forEach((node) => {
+        if (node && !seenNodes.has(node)) {
+          seenNodes.add(node);
+          candidates.push(node);
+        }
+      });
+      idMatches.forEach((node) => {
+        if (node && !seenNodes.has(node)) {
+          seenNodes.add(node);
+          candidates.push(node);
+        }
+      });
     } catch (error) {
       return null;
     }


### PR DESCRIPTION
## Summary
- ensure the JSON code block carrying the thematics suggestions is discoverable via both the data attribute and the generated id
- avoid missing checkbox rendering when only the assistant-thematique-suggestions-* id is present on the code block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e900aa60833080be61af03b5cd7c